### PR TITLE
Derive 106-StockingLocations scope from environment.fsUrl

### DIFF
--- a/samples/106-StockingLocations/plugin_descriptor.json
+++ b/samples/106-StockingLocations/plugin_descriptor.json
@@ -15,10 +15,6 @@
   },
   "securedParams": [
     {
-      "name": "scope",
-      "value": "urn:opc:resource:fa:instanceid=649213527urn:opc:resource:consumer::all"
-    },
-    {
       "name": "enableLogging",
       "value": "true"
     }

--- a/samples/106-StockingLocations/readme.md
+++ b/samples/106-StockingLocations/readme.md
@@ -2,7 +2,7 @@
 
 Oracle Field Service plugin built with Oracle JET MVVM and Redwood styling. This first iteration focuses on browsing service logistics stocking locations from Fusion using the Maintenance Technician Subinventories REST API.
 
-Current scope:
+Current behavior:
 
 - request a Fusion access token through OFS `getAccessTokenByScope`
 - load all technician subinventories from `technicianSubinventories` using `limit=500`
@@ -12,14 +12,20 @@ Current scope:
 
 ## Secure Parameters
 
-The plugin reads these secure params from `securedData`:
+The plugin reads this secure param from `securedData`:
 
-- `scope`: Fusion scope used for `getAccessTokenByScope`
 - `enableLogging`: set to `true` to enable verbose console logging
 
 The Fusion host comes from the OFS open message:
 
 - `environment.faUrl`
+- `environment.fsUrl`
+
+The OFS scope value is derived from `environment.fsUrl` by taking the first hostname segment.
+
+Example:
+
+- `https://ETAQ-DEV4.fs.ocs.oraclecloud.com` -> `ETAQ-DEV4`
 
 ## Plugin Context
 

--- a/samples/106-StockingLocations/src/index.html
+++ b/samples/106-StockingLocations/src/index.html
@@ -75,7 +75,7 @@
         <section class="state-card" data-bind="visible: !loading() && !errorMessage() && !hasLocations()">
           <h2 class="state-card__title">No stocking locations available</h2>
           <p class="state-card__message">
-            Ensure OFS sends <code>environment.faUrl</code> and configure secure parameter <code>scope</code>, then click refresh to retrieve technician subinventories.
+            Ensure OFS sends <code>environment.faUrl</code> and <code>environment.fsUrl</code>, then click refresh to retrieve technician subinventories.
           </p>
         </section>
 

--- a/samples/106-StockingLocations/src/ts/appController.ts
+++ b/samples/106-StockingLocations/src/ts/appController.ts
@@ -22,10 +22,9 @@ import {
   TokenProcedureResult,
 } from "./stocking-locations/types";
 
-const DEFAULT_SCOPE = "urn:opc:resource:consumer::all";
-
 interface PluginConfig {
   faUrl: string;
+  fsUrl: string;
   scope: string;
   enableLogging: boolean;
 }
@@ -140,6 +139,17 @@ class RootViewModel extends OFSPlugin {
     console.error("[stockingLocationsPlugin]", message, detail);
   }
 
+  private deriveScopeFromFsUrl(fsUrl: string): string {
+    try {
+      const hostname = new URL(fsUrl).hostname;
+      const [scope] = hostname.split(".");
+
+      return scope || "";
+    } catch {
+      return "";
+    }
+  }
+
   async init(message: OFSMessage): Promise<OFSMessage> {
     this.info("INIT received", message);
     return {
@@ -157,6 +167,7 @@ class RootViewModel extends OFSPlugin {
     this.info("OPEN received", {
       provider: data.provider,
       faUrl: this.currentConfig.faUrl,
+      fsUrl: this.currentConfig.fsUrl,
       scopeConfigured: Boolean(this.currentConfig.scope),
       securedDataKeys: Object.keys(data.securedData || {}),
       environment: data.environment,
@@ -193,12 +204,12 @@ class RootViewModel extends OFSPlugin {
   }
 
   private buildConfig(data: StockingLocationsOpenMessage): PluginConfig {
+    const scope = this.deriveScopeFromFsUrl(data.environment?.fsUrl || "");
+
     return {
       faUrl: data.environment?.faUrl || "",
-      scope:
-        typeof data.securedData?.scope === "string" && data.securedData.scope.trim()
-          ? data.securedData.scope.trim()
-          : DEFAULT_SCOPE,
+      fsUrl: data.environment?.fsUrl || "",
+      scope,
       enableLogging: String(data.securedData?.enableLogging || "").toLowerCase() === "true",
     };
   }
@@ -212,6 +223,16 @@ class RootViewModel extends OFSPlugin {
       this.fail("Missing Fusion URL in openData.environment.faUrl.");
       return;
     }
+    if (!this.currentConfig.fsUrl) {
+      this.fail("Missing OFS URL in openData.environment.fsUrl.");
+      return;
+    }
+    if (!this.currentConfig.scope) {
+      this.fail("Could not derive scope from openData.environment.fsUrl.", {
+        fsUrl: this.currentConfig.fsUrl,
+      });
+      return;
+    }
     this.errorMessage("");
     this.loading(true);
     this.statusMessage("Requesting Fusion access token...");
@@ -220,12 +241,13 @@ class RootViewModel extends OFSPlugin {
   }
 
   private async requestTokenByScope(): Promise<void> {
-    const scope = this.openData?.securedData?.scope?.trim() || DEFAULT_SCOPE;
+    const scope = this.currentConfig?.scope || "";
 
     this.info("Requesting token by scope", {
       faUrl: this.currentConfig?.faUrl,
+      fsUrl: this.currentConfig?.fsUrl,
       scope,
-      scopeSource: this.openData?.securedData?.scope ? "securedData.scope" : "default",
+      scopeSource: "environment.fsUrl",
     });
 
     this.tokenCallId = this.getAccessTokenByScope(scope);

--- a/samples/106-StockingLocations/src/ts/stocking-locations/types.ts
+++ b/samples/106-StockingLocations/src/ts/stocking-locations/types.ts
@@ -1,7 +1,6 @@
 import { OFSOpenMessage } from "@ofs-users/plugin";
 
 export interface StockingLocationsSecuredData {
-  scope?: string;
   enableLogging?: string;
   [key: string]: unknown;
 }


### PR DESCRIPTION
## Summary
- update samples/106-StockingLocations to derive the OFS token scope from environment.fsUrl
- remove the plugin reliance on securedData.scope and delete the obsolete secure parameter metadata
- update the sample docs and runtime messaging to reflect the new fsUrl-based scope behavior

## Testing
- npm run typecheck in samples/106-StockingLocations
- npm run build in samples/106-StockingLocations
- just package in samples/106-StockingLocations
